### PR TITLE
Replace libgsl2 with libgslcblas0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y \
   clang \
   valgrind \
   gsl-bin \
-  libgsl2 \
+  libgslcblas0 \
   libgsl-dev \
   flex \
   bison \


### PR DESCRIPTION
build error : Package libgsl2 is not available
However the following packages replace it:
libgslcblas0
E: Package 'libgsl2' has no installation candidate